### PR TITLE
Remove biases before Batch Normalization

### DIFF
--- a/xception.py
+++ b/xception.py
@@ -54,44 +54,44 @@ def xception(inputs,
 
             #===========ENTRY FLOW==============
             #Block 1
-            net = slim.conv2d(inputs, 32, [3,3], stride=2, padding='valid', biases_initializer = None, scope='block1_conv1')
+            net = slim.conv2d(inputs, 32, [3,3], stride=2, padding='valid', scope='block1_conv1')
             net = slim.batch_norm(net, scope='block1_bn1')
             net = tf.nn.relu(net, name='block1_relu1')
-            net = slim.conv2d(net, 64, [3,3], padding='valid', biases_initializer = None, scope='block1_conv2')
+            net = slim.conv2d(net, 64, [3,3], padding='valid', scope='block1_conv2')
             net = slim.batch_norm(net, scope='block1_bn2')
             net = tf.nn.relu(net, name='block1_relu2')
-            residual = slim.conv2d(net, 128, [1,1], stride=2, biases_initializer = None, scope='block1_res_conv')
+            residual = slim.conv2d(net, 128, [1,1], stride=2, scope='block1_res_conv')
             residual = slim.batch_norm(residual, scope='block1_res_bn')
 
             #Block 2
-            net = slim.separable_conv2d(net, 128, [3,3], biases_initializer = None, scope='block2_dws_conv1')
+            net = slim.separable_conv2d(net, 128, [3,3], scope='block2_dws_conv1')
             net = slim.batch_norm(net, scope='block2_bn1')
             net = tf.nn.relu(net, name='block2_relu1')
-            net = slim.separable_conv2d(net, 128, [3,3], biases_initializer = None, scope='block2_dws_conv2')
+            net = slim.separable_conv2d(net, 128, [3,3], scope='block2_dws_conv2')
             net = slim.batch_norm(net, scope='block2_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block2_max_pool')
             net = tf.add(net, residual, name='block2_add')
-            residual = slim.conv2d(net, 256, [1,1], stride=2, biases_initializer = None, scope='block2_res_conv')
+            residual = slim.conv2d(net, 256, [1,1], stride=2, scope='block2_res_conv')
             residual = slim.batch_norm(residual, scope='block2_res_bn')
 
             #Block 3
             net = tf.nn.relu(net, name='block3_relu1')
-            net = slim.separable_conv2d(net, 256, [3,3], biases_initializer = None, scope='block3_dws_conv1')
+            net = slim.separable_conv2d(net, 256, [3,3], scope='block3_dws_conv1')
             net = slim.batch_norm(net, scope='block3_bn1')
             net = tf.nn.relu(net, name='block3_relu2')
-            net = slim.separable_conv2d(net, 256, [3,3], biases_initializer = None, scope='block3_dws_conv2')
+            net = slim.separable_conv2d(net, 256, [3,3], scope='block3_dws_conv2')
             net = slim.batch_norm(net, scope='block3_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block3_max_pool')
             net = tf.add(net, residual, name='block3_add')
-            residual = slim.conv2d(net, 728, [1,1], stride=2, biases_initializer = None, scope='block3_res_conv')
+            residual = slim.conv2d(net, 728, [1,1], stride=2, scope='block3_res_conv')
             residual = slim.batch_norm(residual, scope='block3_res_bn')
 
             #Block 4
             net = tf.nn.relu(net, name='block4_relu1')
-            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block4_dws_conv1')
+            net = slim.separable_conv2d(net, 728, [3,3], scope='block4_dws_conv1')
             net = slim.batch_norm(net, scope='block4_bn1')
             net = tf.nn.relu(net, name='block4_relu2')
-            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block4_dws_conv2')
+            net = slim.separable_conv2d(net, 728, [3,3], scope='block4_dws_conv2')
             net = slim.batch_norm(net, scope='block4_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block4_max_pool')
             net = tf.add(net, residual, name='block4_add')
@@ -102,33 +102,33 @@ def xception(inputs,
 
                 residual = net
                 net = tf.nn.relu(net, name=block_prefix+'relu1')
-                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv1')
+                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv1')
                 net = slim.batch_norm(net, scope=block_prefix+'bn1')
                 net = tf.nn.relu(net, name=block_prefix+'relu2')
-                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv2')
+                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv2')
                 net = slim.batch_norm(net, scope=block_prefix+'bn2')
                 net = tf.nn.relu(net, name=block_prefix+'relu3')
-                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv3')
+                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv3')
                 net = slim.batch_norm(net, scope=block_prefix+'bn3')
                 net = tf.add(net, residual, name=block_prefix+'add')
 
 
             #========EXIT FLOW============
-            residual = slim.conv2d(net, 1024, [1,1], stride=2, biases_initializer = None, scope='block12_res_conv')
+            residual = slim.conv2d(net, 1024, [1,1], stride=2, scope='block12_res_conv')
             residual = slim.batch_norm(residual, scope='block12_res_bn')
             net = tf.nn.relu(net, name='block13_relu1')
-            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block13_dws_conv1')
+            net = slim.separable_conv2d(net, 728, [3,3], scope='block13_dws_conv1')
             net = slim.batch_norm(net, scope='block13_bn1')
             net = tf.nn.relu(net, name='block13_relu2')
-            net = slim.separable_conv2d(net, 1024, [3,3], biases_initializer = None, scope='block13_dws_conv2')
+            net = slim.separable_conv2d(net, 1024, [3,3], scope='block13_dws_conv2')
             net = slim.batch_norm(net, scope='block13_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block13_max_pool')
             net = tf.add(net, residual, name='block13_add')
 
-            net = slim.separable_conv2d(net, 1536, [3,3], biases_initializer = None, scope='block14_dws_conv1')
+            net = slim.separable_conv2d(net, 1536, [3,3], scope='block14_dws_conv1')
             net = slim.batch_norm(net, scope='block14_bn1')
             net = tf.nn.relu(net, name='block14_relu1')
-            net = slim.separable_conv2d(net, 2048, [3,3], biases_initializer = None, scope='block14_dws_conv2')
+            net = slim.separable_conv2d(net, 2048, [3,3], scope='block14_dws_conv2')
             net = slim.batch_norm(net, scope='block14_bn2')
             net = tf.nn.relu(net, name='block14_relu2')
 
@@ -162,7 +162,7 @@ def xception_arg_scope(weight_decay=0.00001,
   # Set weight_decay for weights in conv2d and separable_conv2d layers.
   with slim.arg_scope([slim.conv2d, slim.separable_conv2d],
                       weights_regularizer=slim.l2_regularizer(weight_decay),
-                      biases_regularizer=slim.l2_regularizer(weight_decay)):
+                      biases_initializer=None):
             
     # Set parameters for batch_norm. Note: Do not set activation function as it's preset to None already.
     with slim.arg_scope([slim.batch_norm],

--- a/xception.py
+++ b/xception.py
@@ -64,10 +64,10 @@ def xception(inputs,
             residual = slim.batch_norm(residual, scope='block1_res_bn')
 
             #Block 2
-            net = slim.separable_conv2d(net, 128, [3,3], scope='block2_dws_conv1')
+            net = slim.separable_conv2d(net, 128, [3,3], biases_initializer = None, scope='block2_dws_conv1')
             net = slim.batch_norm(net, scope='block2_bn1')
             net = tf.nn.relu(net, name='block2_relu1')
-            net = slim.separable_conv2d(net, 128, [3,3], scope='block2_dws_conv2')
+            net = slim.separable_conv2d(net, 128, [3,3], biases_initializer = None, scope='block2_dws_conv2')
             net = slim.batch_norm(net, scope='block2_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block2_max_pool')
             net = tf.add(net, residual, name='block2_add')
@@ -76,10 +76,10 @@ def xception(inputs,
 
             #Block 3
             net = tf.nn.relu(net, name='block3_relu1')
-            net = slim.separable_conv2d(net, 256, [3,3], scope='block3_dws_conv1')
+            net = slim.separable_conv2d(net, 256, [3,3], biases_initializer = None, scope='block3_dws_conv1')
             net = slim.batch_norm(net, scope='block3_bn1')
             net = tf.nn.relu(net, name='block3_relu2')
-            net = slim.separable_conv2d(net, 256, [3,3], scope='block3_dws_conv2')
+            net = slim.separable_conv2d(net, 256, [3,3], biases_initializer = None, scope='block3_dws_conv2')
             net = slim.batch_norm(net, scope='block3_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block3_max_pool')
             net = tf.add(net, residual, name='block3_add')
@@ -88,10 +88,10 @@ def xception(inputs,
 
             #Block 4
             net = tf.nn.relu(net, name='block4_relu1')
-            net = slim.separable_conv2d(net, 728, [3,3], scope='block4_dws_conv1')
+            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block4_dws_conv1')
             net = slim.batch_norm(net, scope='block4_bn1')
             net = tf.nn.relu(net, name='block4_relu2')
-            net = slim.separable_conv2d(net, 728, [3,3], scope='block4_dws_conv2')
+            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block4_dws_conv2')
             net = slim.batch_norm(net, scope='block4_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block4_max_pool')
             net = tf.add(net, residual, name='block4_add')
@@ -102,13 +102,13 @@ def xception(inputs,
 
                 residual = net
                 net = tf.nn.relu(net, name=block_prefix+'relu1')
-                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv1')
+                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv1')
                 net = slim.batch_norm(net, scope=block_prefix+'bn1')
                 net = tf.nn.relu(net, name=block_prefix+'relu2')
-                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv2')
+                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv2')
                 net = slim.batch_norm(net, scope=block_prefix+'bn2')
                 net = tf.nn.relu(net, name=block_prefix+'relu3')
-                net = slim.separable_conv2d(net, 728, [3,3], scope=block_prefix+'dws_conv3')
+                net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope=block_prefix+'dws_conv3')
                 net = slim.batch_norm(net, scope=block_prefix+'bn3')
                 net = tf.add(net, residual, name=block_prefix+'add')
 
@@ -117,18 +117,18 @@ def xception(inputs,
             residual = slim.conv2d(net, 1024, [1,1], stride=2, biases_initializer = None, scope='block12_res_conv')
             residual = slim.batch_norm(residual, scope='block12_res_bn')
             net = tf.nn.relu(net, name='block13_relu1')
-            net = slim.separable_conv2d(net, 728, [3,3], scope='block13_dws_conv1')
+            net = slim.separable_conv2d(net, 728, [3,3], biases_initializer = None, scope='block13_dws_conv1')
             net = slim.batch_norm(net, scope='block13_bn1')
             net = tf.nn.relu(net, name='block13_relu2')
-            net = slim.separable_conv2d(net, 1024, [3,3], scope='block13_dws_conv2')
+            net = slim.separable_conv2d(net, 1024, [3,3], biases_initializer = None, scope='block13_dws_conv2')
             net = slim.batch_norm(net, scope='block13_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block13_max_pool')
             net = tf.add(net, residual, name='block13_add')
 
-            net = slim.separable_conv2d(net, 1536, [3,3], scope='block14_dws_conv1')
+            net = slim.separable_conv2d(net, 1536, [3,3], biases_initializer = None, scope='block14_dws_conv1')
             net = slim.batch_norm(net, scope='block14_bn1')
             net = tf.nn.relu(net, name='block14_relu1')
-            net = slim.separable_conv2d(net, 2048, [3,3], scope='block14_dws_conv2')
+            net = slim.separable_conv2d(net, 2048, [3,3], biases_initializer = None, scope='block14_dws_conv2')
             net = slim.batch_norm(net, scope='block14_bn2')
             net = tf.nn.relu(net, name='block14_relu2')
 

--- a/xception.py
+++ b/xception.py
@@ -54,13 +54,13 @@ def xception(inputs,
 
             #===========ENTRY FLOW==============
             #Block 1
-            net = slim.conv2d(inputs, 32, [3,3], stride=2, padding='valid', scope='block1_conv1')
+            net = slim.conv2d(inputs, 32, [3,3], stride=2, padding='valid', biases_initializer = None, scope='block1_conv1')
             net = slim.batch_norm(net, scope='block1_bn1')
             net = tf.nn.relu(net, name='block1_relu1')
-            net = slim.conv2d(net, 64, [3,3], padding='valid', scope='block1_conv2')
+            net = slim.conv2d(net, 64, [3,3], padding='valid', biases_initializer = None, scope='block1_conv2')
             net = slim.batch_norm(net, scope='block1_bn2')
             net = tf.nn.relu(net, name='block1_relu2')
-            residual = slim.conv2d(net, 128, [1,1], stride=2, scope='block1_res_conv')
+            residual = slim.conv2d(net, 128, [1,1], stride=2, biases_initializer = None, scope='block1_res_conv')
             residual = slim.batch_norm(residual, scope='block1_res_bn')
 
             #Block 2
@@ -71,7 +71,7 @@ def xception(inputs,
             net = slim.batch_norm(net, scope='block2_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block2_max_pool')
             net = tf.add(net, residual, name='block2_add')
-            residual = slim.conv2d(net, 256, [1,1], stride=2, scope='block2_res_conv')
+            residual = slim.conv2d(net, 256, [1,1], stride=2, biases_initializer = None, scope='block2_res_conv')
             residual = slim.batch_norm(residual, scope='block2_res_bn')
 
             #Block 3
@@ -83,7 +83,7 @@ def xception(inputs,
             net = slim.batch_norm(net, scope='block3_bn2')
             net = slim.max_pool2d(net, [3,3], stride=2, padding='same', scope='block3_max_pool')
             net = tf.add(net, residual, name='block3_add')
-            residual = slim.conv2d(net, 728, [1,1], stride=2, scope='block3_res_conv')
+            residual = slim.conv2d(net, 728, [1,1], stride=2, biases_initializer = None, scope='block3_res_conv')
             residual = slim.batch_norm(residual, scope='block3_res_bn')
 
             #Block 4
@@ -114,7 +114,7 @@ def xception(inputs,
 
 
             #========EXIT FLOW============
-            residual = slim.conv2d(net, 1024, [1,1], stride=2, scope='block12_res_conv')
+            residual = slim.conv2d(net, 1024, [1,1], stride=2, biases_initializer = None, scope='block12_res_conv')
             residual = slim.batch_norm(residual, scope='block12_res_bn')
             net = tf.nn.relu(net, name='block13_relu1')
             net = slim.separable_conv2d(net, 728, [3,3], scope='block13_dws_conv1')


### PR DESCRIPTION
Biases are negated by the internal bias (mean) of batch normalization, they can be removed without any harm, saving some memory and compute effort.

I haven't tested this myself as I can't train for any decent length at the moment, so perhaps somebody can test it before merging.